### PR TITLE
Fix: Prevent Chat History and Avatar Rendering Without API Key

### DIFF
--- a/src/content/content.tsx
+++ b/src/content/content.tsx
@@ -1,15 +1,15 @@
-import React, { useRef } from 'react';
-import { Button } from '@/components/ui/button';
-import { Bot, SendHorizontal } from 'lucide-react';
-import OpenAI from 'openai';
+import React, { useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { Bot, SendHorizontal } from "lucide-react";
+import OpenAI from "openai";
 
-import './style.css';
-import { Input } from '@/components/ui/input';
-import { SYSTEM_PROMPT } from '@/constants/prompt';
-import { extractCode } from './util';
-import { ChatCompletionMessageParam } from 'openai/resources/index.mjs';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import Markdown from 'react-markdown';
+import "./style.css";
+import { Input } from "@/components/ui/input";
+import { SYSTEM_PROMPT } from "@/constants/prompt";
+import { extractCode } from "./util";
+import { ChatCompletionMessageParam } from "openai/resources/index.mjs";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import Markdown from "react-markdown";
 
 function createOpenAISDK(apiKey: string) {
   return new OpenAI({
@@ -26,45 +26,49 @@ interface ChatBoxProps {
 }
 
 interface ChatMessage {
-  role: 'user' | 'assistant';
+  role: "user" | "assistant";
   message: string;
-  type: 'text' | 'markdown';
+  type: "text" | "markdown";
 }
 
 function ChatBox({ context }: ChatBoxProps) {
-  const [value, setValue] = React.useState('');
+  const [value, setValue] = React.useState("");
   const [chatHistory, setChatHistory] = React.useState<ChatMessage[]>([]);
+  const [isApiKeyProvided, setIsApiKeyProvided] = React.useState(false);
 
   const chatBoxRef = useRef<HTMLDivElement>(null);
 
   const handleGenerateAIResponse = async () => {
-    const openAIAPIKey = (await chrome.storage.local.get('apiKey')) as {
+    const openAIAPIKey = (await chrome.storage.local.get("apiKey")) as {
       apiKey?: string;
     };
-
-    if (!openAIAPIKey.apiKey) return alert('OpenAI API Key is required');
+    if (!openAIAPIKey.apiKey) {
+      setIsApiKeyProvided(false);
+      return alert("OpenAI API Key is required");
+    }
+    setIsApiKeyProvided(true);
 
     const openai = createOpenAISDK(openAIAPIKey.apiKey);
 
     const userMessage = value;
-    const userCurrentCodeContainer = document.querySelector('.view-line');
+    const userCurrentCodeContainer = document.querySelector(".view-line");
 
     const extractedCode = extractCode(
-      userCurrentCodeContainer?.innerHTML ?? ''
+      userCurrentCodeContainer?.innerHTML ?? ""
     );
 
     const systemPromptModified = SYSTEM_PROMPT.replace(
-      '{{problem_statement}}',
+      "{{problem_statement}}",
       context.problemStatement
     )
-      .replace('{{programming_language}}', context.programmingLanguage)
-      .replace('{{user_code}}', extractedCode);
+      .replace("{{programming_language}}", context.programmingLanguage)
+      .replace("{{user_code}}", extractedCode);
 
     const apiResponse = await openai.chat.completions.create({
-      model: 'chatgpt-4o-latest',
-      response_format: { type: 'json_object' },
+      model: "chatgpt-4o-latest",
+      response_format: { type: "json_object" },
       messages: [
-        { role: 'system', content: systemPromptModified },
+        { role: "system", content: systemPromptModified },
         ...chatHistory.map(
           (chat) =>
             ({
@@ -72,18 +76,18 @@ function ChatBox({ context }: ChatBoxProps) {
               content: chat.message,
             } as ChatCompletionMessageParam)
         ),
-        { role: 'user', content: userMessage },
+        { role: "user", content: userMessage },
       ],
     });
 
     if (apiResponse.choices[0].message.content) {
       const result = JSON.parse(apiResponse.choices[0].message.content);
-      if ('output' in result) {
+      if ("output" in result) {
         setChatHistory((prev) => [
           ...prev,
-          { message: result.output, role: 'user', type: 'markdown' },
+          { message: result.output, role: "user", type: "markdown" },
         ]);
-        chatBoxRef.current?.scrollIntoView({ behavior: 'smooth' });
+        chatBoxRef.current?.scrollIntoView({ behavior: "smooth" });
       }
     }
   };
@@ -91,42 +95,44 @@ function ChatBox({ context }: ChatBoxProps) {
   const onSendMessage = () => {
     setChatHistory((prev) => [
       ...prev,
-      { role: 'user', message: value, type: 'text' },
+      { role: "user", message: value, type: "text" },
     ]);
-    setValue('');
-    chatBoxRef.current?.scrollIntoView({ behavior: 'smooth' });
+    setValue("");
+    chatBoxRef.current?.scrollIntoView({ behavior: "smooth" });
     handleGenerateAIResponse();
   };
   return (
     <div className="w-[400px] h-[550px] mb-2 rounded-xl relative text-wrap overflow-auto">
-      <div className="h-[510px] overflow-auto" ref={chatBoxRef}>
-        {chatHistory.map((message, index) => (
-          <div
-            key={index.toString()}
-            className="flex gap-4 mt-3 w-[400px] text-wrap"
-          >
-            <Avatar>
-              <AvatarImage src="https://github.com/shadcn.png" />
-              <AvatarFallback>CN</AvatarFallback>
-            </Avatar>
-            <div className="w-[100%]">
-              <p>{message.role.toLocaleUpperCase()}</p>
-              {message.type === 'markdown' ? (
-                <Markdown>{message.message}</Markdown>
-              ) : (
-                <p>{message.message}</p>
-              )}
+      {isApiKeyProvided && (
+        <div className="h-[510px] overflow-auto" ref={chatBoxRef}>
+          {chatHistory.map((message, index) => (
+            <div
+              key={index.toString()}
+              className="flex gap-4 mt-3 w-[400px] text-wrap"
+            >
+              <Avatar>
+                <AvatarImage src="https://github.com/shadcn.png" />
+                <AvatarFallback>CN</AvatarFallback>
+              </Avatar>
+              <div className="w-[100%]">
+                <p>{message.role.toLocaleUpperCase()}</p>
+                {message.type === "markdown" ? (
+                  <Markdown>{message.message}</Markdown>
+                ) : (
+                  <p>{message.message}</p>
+                )}
+              </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
 
       <div className="absolute bottom-0 w-full flex items-center gap-2">
         <Input
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === 'Enter') onSendMessage();
+            if (e.key === "Enter") onSendMessage();
           }}
           className="rounded-lg bg-black"
           placeholder="Type your message here"
@@ -140,14 +146,14 @@ function ChatBox({ context }: ChatBoxProps) {
 const ContentPage: React.FC = () => {
   const [chatboxExpanded, setChatboxExpanded] = React.useState(false);
 
-  const metaDescriptionEl = document.querySelector('meta[name=description]');
+  const metaDescriptionEl = document.querySelector("meta[name=description]");
 
-  const problemStatement = metaDescriptionEl?.getAttribute('content') as string;
+  const problemStatement = metaDescriptionEl?.getAttribute("content") as string;
 
   return (
     <div className="__chat-container dark">
       {chatboxExpanded && (
-        <ChatBox context={{ problemStatement, programmingLanguage: 'C++' }} />
+        <ChatBox context={{ problemStatement, programmingLanguage: "C++" }} />
       )}
       <div className="flex justify-end">
         <Button onClick={() => setChatboxExpanded(!chatboxExpanded)}>


### PR DESCRIPTION
## Description

This PR addresses an issue where the ChatBox component was still rendering the chat history and avatar images, even if the user had not provided an API key. With these changes, the component now checks for the presence of an API key before rendering chat elements. If no API key is provided, an alert notifies the user that an OpenAI API key is required, and the chat history and avatars remain hidden until the key is supplied.

## Changes
- Added a state variable isApiKeyProvided to conditionally render chat history and avatars.
- Added conditional rendering for the chat display based on the isApiKeyProvided state.
## Problem

[Untitled Video November 15, 2024 8_44 PM.webm](https://github.com/user-attachments/assets/e0f0f890-b54c-43a2-ace2-4f395e534dcd)

## Fix
[Untitled Video November 15, 2024 9_03 PM.webm](https://github.com/user-attachments/assets/4bf65ed4-54db-49e0-a75c-2ec35938b90f)

## Additional Note
- The window alert not captured by the video recorder