### PR TITLE
#34 Feat: added skewness and remove button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,15 +5,16 @@ import { Button } from './components/ui/button';
 
 const Popup: React.FC = () => {
   const [openAIKey, setOpenAIKey] = React.useState('');
+  const [skewedKey, setSkewedKey] = React.useState('');
   const [isLoaded, setIsLoaded] = React.useState(false);
 
   React.useEffect(() => {
     (async function loadOpenAPIKey() {
       if (!chrome) return;
-      const apiKeyFromStorage = (await chrome.storage.local.get('apiKey')) as {
-        apiKey?: string;
-      };
-      if (apiKeyFromStorage.apiKey) setOpenAIKey(apiKeyFromStorage.apiKey);
+      const apiKey = (await chrome.storage.local.get('apiKey')).apiKey;
+      if (apiKey) {
+        setSkewedKey(obscureKey(apiKey));
+      }
       setIsLoaded(true);
     })();
   }, []);
@@ -21,8 +22,16 @@ const Popup: React.FC = () => {
   const handleAddOpenAPIKey = async () => {
     if (openAIKey) {
       await chrome.storage.local.set({ apiKey: openAIKey });
+      setSkewedKey(obscureKey(openAIKey));
+      setOpenAIKey('');
     }
   };
+
+  async function removeOpenAPIKey() {
+    await chrome.storage.local.remove('apiKey');
+    setOpenAIKey('');
+    setSkewedKey('');
+  }
 
   return (
     <div className="dark relative w-[350px] h-[550px] bg-black text-white p-4">
@@ -35,15 +44,21 @@ const Popup: React.FC = () => {
             <h1 className="text-white font-bold text-2xl">LeetCode Whisper</h1>
           </div>
           <div className="mt-10 flex flex-col gap-2">
-            <label htmlFor="text" className='text-white font-bold text-xl'>Enter Your OpenAI API key</label>
+            <label htmlFor="text" className="text-white font-bold text-xl">
+              Enter Your OpenAI API key
+            </label>
             <Input
-              value={openAIKey}
+              value={openAIKey || skewedKey}
               onChange={(e) => setOpenAIKey(e.target.value)}
               placeholder="Ex. 0aBbnGgzXXXXXX"
-              className='bg-white outline-none'
+              className="bg-white outline-none text-black"
             />
             <Button onClick={handleAddOpenAPIKey} className="dark">
               Save
+            </Button>
+
+            <Button onClick={removeOpenAPIKey} variant={'outline'}>
+              Clear
             </Button>
           </div>
         </div>
@@ -51,5 +66,18 @@ const Popup: React.FC = () => {
     </div>
   );
 };
+
+// Replace the middle of the string with asterisks
+function obscureKey(key: string, visibleStart = 7, visibleEnd = 4) {
+  if (key.length <= visibleStart + visibleEnd) {
+    return key;
+  }
+
+  const start = key.slice(0, visibleStart);
+  const end = key.slice(-visibleEnd);
+  const hiddenPart = '*'.repeat(key.length - visibleStart - visibleEnd);
+
+  return `${start}${hiddenPart}${end}`;
+}
 
 export default Popup;


### PR DESCRIPTION
This pull request adds the ability to skew the user's OpenAI API key and provides a button to remove the skewed key. The key is skewed by replacing the middle part with asterisks, leaving the first and last few characters visible. This helps enhance the security of the API key by obfuscating the sensitive information. Additionally, a new button is added to the UI that allows the user to remove the skewed key, effectively clearing the saved API key.
The changes are small and focused, improving the user experience and security of the extension without introducing any major functionality changes.

issue #34 

![image](https://github.com/user-attachments/assets/e005d311-1b2d-4745-beab-2580e9e608d5)
