### PR TITLE
[BUG 🐛] : Properly align the white border while hovering on the inputbox.

### DIFF
--- a/src/content/content.tsx
+++ b/src/content/content.tsx
@@ -121,7 +121,7 @@ function ChatBox({ context }: ChatBoxProps) {
         ))}
       </div>
 
-      <div className="absolute bottom-0 w-full flex items-center gap-2">
+      <div className="bottom-0 w-[90%] flex items-center m-auto gap-2">
         <Input
           value={value}
           onChange={(e) => setValue(e.target.value)}


### PR DESCRIPTION
#60 
Just Fixed This Issue by changing 2 props of tailwind and here is the result ->
![image](https://github.com/user-attachments/assets/839811c4-5edf-4d2a-bd2d-e65cf54d84c6)

@piyushgarg-dev ⬆️