### PR TITLE
feat: add react-draggable for draggable chat container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "react-ace": "^13.0.0",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
+        "react-draggable": "^4.4.6",
         "react-hook-form": "^7.53.2",
         "react-markdown": "^9.0.1",
         "react-resizable-panels": "^2.1.6",
@@ -7399,6 +7400,29 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-draggable": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
+      "integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-draggable/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react-hook-form": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-ace": "^13.0.0",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
+    "react-draggable": "^4.4.6",
     "react-hook-form": "^7.53.2",
     "react-markdown": "^9.0.1",
     "react-resizable-panels": "^2.1.6",

--- a/src/content/content.tsx
+++ b/src/content/content.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Bot, ClipboardCopy, Send, SendHorizontal } from 'lucide-react';
 import OpenAI from 'openai';
-
+import Draggable from 'react-draggable';
 import './style.css';
 import { Input } from '@/components/ui/input';
 import { SYSTEM_PROMPT } from '@/constants/prompt';
@@ -234,7 +234,8 @@ const ContentPage: React.FC = () => {
   const problemStatement = metaDescriptionEl?.getAttribute('content') as string
 
   return (
-    <div className="__chat-container dark z-50">
+    <Draggable bounds="body">
+      <div className="__chat-container dark z-50">
       <ChatBox visible={chatboxExpanded} context={{ problemStatement }} />
       <div className="flex justify-end">
         <Button onClick={() => setChatboxExpanded(!chatboxExpanded)}>
@@ -243,6 +244,8 @@ const ContentPage: React.FC = () => {
         </Button>
       </div>
     </div>
+    </Draggable>
+
   )
 }
 


### PR DESCRIPTION
Description: This PR introduces a draggable feature to the chatbot extension, allowing users to move the chatbox freely across the screen. This enhancement improves the user experience by enabling better positioning of the chatbox to suit individual preferences.

Screenshots/Demo:

https://github.com/user-attachments/assets/1349606c-ee72-4f66-b55e-cc42cde6d06f

